### PR TITLE
fixed wrong list flashing when getting team suggestions

### DIFF
--- a/app/src/main/java/com/example/pokedex/ui/mainViews/MyTeamsView/MyTeamsViewModel.kt
+++ b/app/src/main/java/com/example/pokedex/ui/mainViews/MyTeamsView/MyTeamsViewModel.kt
@@ -82,7 +82,7 @@ class MyTeamsViewModel : ViewModel() {
         }
         teamToEdit = teamName
         isShowingAddPokemon = true
-        addToTeamViewModel = AddToTeamViewModel(teamName, {isShowingAddPokemon = false})
+        addToTeamViewModel = AddToTeamViewModel(teamName) { isShowingAddPokemon = false }
     }
 
 }

--- a/app/src/main/java/com/example/pokedex/ui/mainViews/SearchView/SearchViewModel.kt
+++ b/app/src/main/java/com/example/pokedex/ui/mainViews/SearchView/SearchViewModel.kt
@@ -46,7 +46,6 @@ open class SearchViewModel: ViewModel() {
                 }
             }
         }
-        searchPokemonList()
     }
 
     open fun searchPokemonList() {

--- a/app/src/main/java/com/example/pokedex/ui/mainViews/addToTeamView/AddToTeamViewModel.kt
+++ b/app/src/main/java/com/example/pokedex/ui/mainViews/addToTeamView/AddToTeamViewModel.kt
@@ -3,7 +3,6 @@ package com.example.pokedex.ui.mainViews.addToTeamView
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.NavController
 import com.example.pokedex.dataClasses.Pokemon
-import com.example.pokedex.dependencyContainer.DependencyContainer
 import com.example.pokedex.mainViews.SearchView.SearchUIState
 import com.example.pokedex.mainViews.SearchView.SearchViewModel
 import com.example.pokedex.ui.navigation.Screen
@@ -16,7 +15,7 @@ class AddToTeamViewModel(private val teamName: String, private val dismiss: () -
             SearchUIState.Loading
         }
 
-        if (searchText.value.isEmpty() && selectedFilterOptionsList.value.isEmpty() && selectedSortOption.value.isEmpty() && teamName != null)
+        if (searchText.value.isEmpty() && selectedFilterOptionsList.value.isEmpty() && selectedSortOption.value.isEmpty())
         {
             viewModelScope.launch {
                 teamsRepository.fetchTeamSuggestions(teamName)


### PR DESCRIPTION
The issue was that searchPokemonList() was called both in the view models init and in a launched effect. This caused two lists to be imitted right after each other. This was also the reason why we had to check if the team name was null in the addToTeamViewModel.